### PR TITLE
Modify Volume delete interface

### DIFF
--- a/telefonicaopencloud/config.go
+++ b/telefonicaopencloud/config.go
@@ -493,3 +493,17 @@ func (c *Config) sfsV2Client(region string) (*golangsdk.ServiceClient, error) {
 		Availability: c.getHwEndpointType(),
 	})
 }
+
+func (c *Config) loadEVSV2Client(region string) (*golangsdk.ServiceClient, error) {
+	return huaweisdk.NewBlockStorageV2(c.HwClient, golangsdk.EndpointOpts{
+		Region:       c.determineRegion(region),
+		Availability: c.getHwEndpointType(),
+	})
+}
+
+func (c *Config) computeV2HWClient(region string) (*golangsdk.ServiceClient, error) {
+	return huaweisdk.NewComputeV2(c.HwClient, golangsdk.EndpointOpts{
+		Region:       c.determineRegion(region),
+		Availability: c.getHwEndpointType(),
+	})
+}

--- a/telefonicaopencloud/import_telefonicaopencloud_blockstorage_volume_v2_test.go
+++ b/telefonicaopencloud/import_telefonicaopencloud_blockstorage_volume_v2_test.go
@@ -22,6 +22,9 @@ func TestAccBlockStorageV2Volume_importBasic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"cascade",
+				},
 			},
 		},
 	})

--- a/telefonicaopencloud/resource_telefonicaopencloud_blockstorage_volume_v2.go
+++ b/telefonicaopencloud/resource_telefonicaopencloud_blockstorage_volume_v2.go
@@ -6,12 +6,12 @@ import (
 	"log"
 	"time"
 
-	"github.com/gophercloud/gophercloud"
-	"github.com/gophercloud/gophercloud/openstack/blockstorage/v2/volumes"
-	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/volumeattach"
 	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/openstack/blockstorage/v2/volumes"
+	"github.com/huaweicloud/golangsdk/openstack/compute/v2/extensions/volumeattach"
 )
 
 func resourceBlockStorageVolumeV2() *schema.Resource {
@@ -116,13 +116,18 @@ func resourceBlockStorageVolumeV2() *schema.Resource {
 				},
 				Set: resourceVolumeV2AttachmentHash,
 			},
+			"cascade": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 		},
 	}
 }
 
 func resourceBlockStorageVolumeV2Create(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	blockStorageClient, err := config.blockStorageV2Client(GetRegion(d, config))
+	blockStorageClient, err := config.loadEVSV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating TelefonicaOpenCloud block storage client: %s", err)
 	}
@@ -177,7 +182,7 @@ func resourceBlockStorageVolumeV2Create(d *schema.ResourceData, meta interface{}
 
 func resourceBlockStorageVolumeV2Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	blockStorageClient, err := config.blockStorageV2Client(GetRegion(d, config))
+	blockStorageClient, err := config.loadEVSV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating TelefonicaOpenCloud block storage client: %s", err)
 	}
@@ -228,7 +233,7 @@ OUTER:
 
 func resourceBlockStorageVolumeV2Update(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	blockStorageClient, err := config.blockStorageV2Client(GetRegion(d, config))
+	blockStorageClient, err := config.loadEVSV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating TelefonicaOpenCloud block storage client: %s", err)
 	}
@@ -252,7 +257,7 @@ func resourceBlockStorageVolumeV2Update(d *schema.ResourceData, meta interface{}
 
 func resourceBlockStorageVolumeV2Delete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	blockStorageClient, err := config.blockStorageV2Client(GetRegion(d, config))
+	blockStorageClient, err := config.loadEVSV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating TelefonicaOpenCloud block storage client: %s", err)
 	}
@@ -265,7 +270,7 @@ func resourceBlockStorageVolumeV2Delete(d *schema.ResourceData, meta interface{}
 	// make sure this volume is detached from all instances before deleting
 	if len(v.Attachments) > 0 {
 		log.Printf("[DEBUG] detaching volumes")
-		if computeClient, err := config.computeV2Client(GetRegion(d, config)); err != nil {
+		if computeClient, err := config.computeV2HWClient(GetRegion(d, config)); err != nil {
 			return err
 		} else {
 			for _, volumeAttachment := range v.Attachments {
@@ -293,11 +298,15 @@ func resourceBlockStorageVolumeV2Delete(d *schema.ResourceData, meta interface{}
 		}
 	}
 
+	// The snapshots associated with the disk are deleted together with the EVS disk if cascade value is true
+	deleteOpts := volumes.DeleteOpts{
+		Cascade: d.Get("cascade").(bool),
+	}
 	// It's possible that this volume was used as a boot device and is currently
 	// in a "deleting" state from when the instance was terminated.
 	// If this is true, just move on. It'll eventually delete.
 	if v.Status != "deleting" {
-		if err := volumes.Delete(blockStorageClient, d.Id()).ExtractErr(); err != nil {
+		if err := volumes.Delete(blockStorageClient, d.Id(), deleteOpts).ExtractErr(); err != nil {
 			return CheckDeleted(d, err, "volume")
 		}
 	}
@@ -335,11 +344,11 @@ func resourceVolumeMetadataV2(d *schema.ResourceData) map[string]string {
 
 // VolumeV2StateRefreshFunc returns a resource.StateRefreshFunc that is used to watch
 // an TelefonicaOpenCloud volume.
-func VolumeV2StateRefreshFunc(client *gophercloud.ServiceClient, volumeID string) resource.StateRefreshFunc {
+func VolumeV2StateRefreshFunc(client *golangsdk.ServiceClient, volumeID string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		v, err := volumes.Get(client, volumeID).Extract()
 		if err != nil {
-			if _, ok := err.(gophercloud.ErrDefault404); ok {
+			if _, ok := err.(golangsdk.ErrDefault404); ok {
 				return v, "deleted", nil
 			}
 			return nil, "", err

--- a/telefonicaopencloud/resource_telefonicaopencloud_blockstorage_volume_v2_test.go
+++ b/telefonicaopencloud/resource_telefonicaopencloud_blockstorage_volume_v2_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 
-	"github.com/gophercloud/gophercloud"
-	"github.com/gophercloud/gophercloud/openstack/blockstorage/v2/volumes"
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/openstack/blockstorage/v2/volumes"
 )
 
 func TestAccBlockStorageV2Volume_basic(t *testing.T) {
@@ -81,7 +81,7 @@ func TestAccBlockStorageV2Volume_timeout(t *testing.T) {
 
 func testAccCheckBlockStorageV2VolumeDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
-	blockStorageClient, err := config.blockStorageV2Client(OS_REGION_NAME)
+	blockStorageClient, err := config.loadEVSV2Client(OS_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating TelefonicaOpenCloud block storage client: %s", err)
 	}
@@ -112,7 +112,7 @@ func testAccCheckBlockStorageV2VolumeExists(n string, volume *volumes.Volume) re
 		}
 
 		config := testAccProvider.Meta().(*Config)
-		blockStorageClient, err := config.blockStorageV2Client(OS_REGION_NAME)
+		blockStorageClient, err := config.loadEVSV2Client(OS_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating TelefonicaOpenCloud block storage client: %s", err)
 		}
@@ -135,14 +135,14 @@ func testAccCheckBlockStorageV2VolumeExists(n string, volume *volumes.Volume) re
 func testAccCheckBlockStorageV2VolumeDoesNotExist(t *testing.T, n string, volume *volumes.Volume) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		config := testAccProvider.Meta().(*Config)
-		blockStorageClient, err := config.blockStorageV2Client(OS_REGION_NAME)
+		blockStorageClient, err := config.loadEVSV2Client(OS_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating TelefonicaOpenCloud block storage client: %s", err)
 		}
 
 		_, err = volumes.Get(blockStorageClient, volume.ID).Extract()
 		if err != nil {
-			if _, ok := err.(gophercloud.ErrDefault404); ok {
+			if _, ok := err.(golangsdk.ErrDefault404); ok {
 				return nil
 			}
 			return err

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/blockstorage/v2/volumes/doc.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/blockstorage/v2/volumes/doc.go
@@ -1,0 +1,5 @@
+// Package volumes provides information and interaction with volumes in the
+// OpenStack Block Storage service. A volume is a detachable block storage
+// device, akin to a USB hard drive. It can only be attached to one instance at
+// a time.
+package volumes

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/blockstorage/v2/volumes/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/blockstorage/v2/volumes/requests.go
@@ -1,0 +1,232 @@
+package volumes
+
+import (
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/pagination"
+)
+
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
+type CreateOptsBuilder interface {
+	ToVolumeCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts contains options for creating a Volume. This object is passed to
+// the volumes.Create function. For more information about these parameters,
+// see the Volume object.
+type CreateOpts struct {
+	// The size of the volume, in GB
+	Size int `json:"size" required:"true"`
+	// The availability zone
+	AvailabilityZone string `json:"availability_zone,omitempty"`
+	// ConsistencyGroupID is the ID of a consistency group
+	ConsistencyGroupID string `json:"consistencygroup_id,omitempty"`
+	// The volume description
+	Description string `json:"description,omitempty"`
+	// One or more metadata key and value pairs to associate with the volume
+	Metadata map[string]string `json:"metadata,omitempty"`
+	// The volume name
+	Name string `json:"name,omitempty"`
+	// the ID of the existing volume snapshot
+	SnapshotID string `json:"snapshot_id,omitempty"`
+	// SourceReplica is a UUID of an existing volume to replicate with
+	SourceReplica string `json:"source_replica,omitempty"`
+	// the ID of the existing volume
+	SourceVolID string `json:"source_volid,omitempty"`
+	// The ID of the image from which you want to create the volume.
+	// Required to create a bootable volume.
+	ImageID string `json:"imageRef,omitempty"`
+	// The associated volume type
+	VolumeType string `json:"volume_type,omitempty"`
+}
+
+// ToVolumeCreateMap assembles a request body based on the contents of a
+// CreateOpts.
+func (opts CreateOpts) ToVolumeCreateMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "volume")
+}
+
+// Create will create a new Volume based on the values in CreateOpts. To extract
+// the Volume object from the response, call the Extract method on the
+// CreateResult.
+func Create(client *golangsdk.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToVolumeCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(createURL(client), b, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{202},
+	})
+	return
+}
+
+//DeleteOptsBuilder is an interface by which can be able to build the query string
+//of volume deletion.
+type DeleteOptsBuilder interface {
+	ToVolumeDeleteQuery() (string, error)
+}
+
+type DeleteOpts struct {
+	//Specifies to delete all snapshots associated with the EVS disk.
+	Cascade bool `q:"cascade"`
+}
+
+func (opts DeleteOpts) ToVolumeDeleteQuery() (string, error) {
+	q, err := golangsdk.BuildQueryString(opts)
+	return q.String(), err
+}
+
+//Delete will delete the existing Volume with the provided ID
+func Delete(client *golangsdk.ServiceClient, id string, opts DeleteOptsBuilder) (r DeleteResult) {
+	url := deleteURL(client, id)
+	if opts != nil {
+		q, err := opts.ToVolumeDeleteQuery()
+		if err != nil {
+			r.Err = err
+			return
+		}
+		url += q
+	}
+	_, r.Err = client.Delete(url, nil)
+	return
+}
+
+// Get retrieves the Volume with the provided ID. To extract the Volume object
+// from the response, call the Extract method on the GetResult.
+func Get(client *golangsdk.ServiceClient, id string) (r GetResult) {
+	_, r.Err = client.Get(getURL(client, id), &r.Body, nil)
+	return
+}
+
+// ListOptsBuilder allows extensions to add additional parameters to the List
+// request.
+type ListOptsBuilder interface {
+	ToVolumeListQuery() (string, error)
+}
+
+// ListOpts holds options for listing Volumes. It is passed to the volumes.List
+// function.
+type ListOpts struct {
+	// AllTenants will retrieve volumes of all tenants/projects.
+	AllTenants bool `q:"all_tenants"`
+
+	// Metadata will filter results based on specified metadata.
+	Metadata map[string]string `q:"metadata"`
+
+	// Name will filter by the specified volume name.
+	Name string `q:"name"`
+
+	// Status will filter by the specified status.
+	Status string `q:"status"`
+
+	// TenantID will filter by a specific tenant/project ID.
+	// Setting AllTenants is required for this.
+	TenantID string `q:"project_id"`
+
+	// Comma-separated list of sort keys and optional sort directions in the
+	// form of <key>[:<direction>].
+	Sort string `q:"sort"`
+
+	// Requests a page size of items.
+	Limit int `q:"limit"`
+
+	// Used in conjunction with limit to return a slice of items.
+	Offset int `q:"offset"`
+
+	// The ID of the last-seen item.
+	Marker string `q:"marker"`
+}
+
+// ToVolumeListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToVolumeListQuery() (string, error) {
+	q, err := golangsdk.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List returns Volumes optionally limited by the conditions provided in ListOpts.
+func List(client *golangsdk.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(client)
+	if opts != nil {
+		query, err := opts.ToVolumeListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return VolumePage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// UpdateOptsBuilder allows extensions to add additional parameters to the
+// Update request.
+type UpdateOptsBuilder interface {
+	ToVolumeUpdateMap() (map[string]interface{}, error)
+}
+
+// UpdateOpts contain options for updating an existing Volume. This object is passed
+// to the volumes.Update function. For more information about the parameters, see
+// the Volume object.
+type UpdateOpts struct {
+	Name        string            `json:"name,omitempty"`
+	Description string            `json:"description,omitempty"`
+	Metadata    map[string]string `json:"metadata,omitempty"`
+}
+
+// ToVolumeUpdateMap assembles a request body based on the contents of an
+// UpdateOpts.
+func (opts UpdateOpts) ToVolumeUpdateMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "volume")
+}
+
+// Update will update the Volume with provided information. To extract the updated
+// Volume from the response, call the Extract method on the UpdateResult.
+func Update(client *golangsdk.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToVolumeUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Put(updateURL(client, id), b, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// IDFromName is a convienience function that returns a server's ID given its name.
+func IDFromName(client *golangsdk.ServiceClient, name string) (string, error) {
+	count := 0
+	id := ""
+
+	listOpts := ListOpts{
+		Name: name,
+	}
+
+	pages, err := List(client, listOpts).AllPages()
+	if err != nil {
+		return "", err
+	}
+
+	all, err := ExtractVolumes(pages)
+	if err != nil {
+		return "", err
+	}
+
+	for _, s := range all {
+		if s.Name == name {
+			count++
+			id = s.ID
+		}
+	}
+
+	switch count {
+	case 0:
+		return "", golangsdk.ErrResourceNotFound{Name: name, ResourceType: "volume"}
+	case 1:
+		return id, nil
+	default:
+		return "", golangsdk.ErrMultipleResourcesFound{Name: name, Count: count, ResourceType: "volume"}
+	}
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/blockstorage/v2/volumes/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/blockstorage/v2/volumes/results.go
@@ -1,0 +1,167 @@
+package volumes
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/pagination"
+)
+
+type Attachment struct {
+	AttachedAt   time.Time `json:"-"`
+	AttachmentID string    `json:"attachment_id"`
+	Device       string    `json:"device"`
+	HostName     string    `json:"host_name"`
+	ID           string    `json:"id"`
+	ServerID     string    `json:"server_id"`
+	VolumeID     string    `json:"volume_id"`
+}
+
+func (r *Attachment) UnmarshalJSON(b []byte) error {
+	type tmp Attachment
+	var s struct {
+		tmp
+		AttachedAt golangsdk.JSONRFC3339MilliNoZ `json:"attached_at"`
+	}
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+	*r = Attachment(s.tmp)
+
+	r.AttachedAt = time.Time(s.AttachedAt)
+
+	return err
+}
+
+// Volume contains all the information associated with an OpenStack Volume.
+type Volume struct {
+	// Unique identifier for the volume.
+	ID string `json:"id"`
+	// Current status of the volume.
+	Status string `json:"status"`
+	// Size of the volume in GB.
+	Size int `json:"size"`
+	// AvailabilityZone is which availability zone the volume is in.
+	AvailabilityZone string `json:"availability_zone"`
+	// The date when this volume was created.
+	CreatedAt time.Time `json:"-"`
+	// The date when this volume was last updated
+	UpdatedAt time.Time `json:"-"`
+	// Instances onto which the volume is attached.
+	Attachments []Attachment `json:"attachments"`
+	// Human-readable display name for the volume.
+	Name string `json:"name"`
+	// Human-readable description for the volume.
+	Description string `json:"description"`
+	// The type of volume to create, either SATA or SSD.
+	VolumeType string `json:"volume_type"`
+	// The ID of the snapshot from which the volume was created
+	SnapshotID string `json:"snapshot_id"`
+	// The ID of another block storage volume from which the current volume was created
+	SourceVolID string `json:"source_volid"`
+	// Arbitrary key-value pairs defined by the user.
+	Metadata map[string]string `json:"metadata"`
+	// UserID is the id of the user who created the volume.
+	UserID string `json:"user_id"`
+	// Indicates whether this is a bootable volume.
+	Bootable string `json:"bootable"`
+	// Encrypted denotes if the volume is encrypted.
+	Encrypted bool `json:"encrypted"`
+	// ReplicationStatus is the status of replication.
+	ReplicationStatus string `json:"replication_status"`
+	// ConsistencyGroupID is the consistency group ID.
+	ConsistencyGroupID string `json:"consistencygroup_id"`
+	// Multiattach denotes if the volume is multi-attach capable.
+	Multiattach bool `json:"multiattach"`
+}
+
+func (r *Volume) UnmarshalJSON(b []byte) error {
+	type tmp Volume
+	var s struct {
+		tmp
+		CreatedAt golangsdk.JSONRFC3339MilliNoZ `json:"created_at"`
+		UpdatedAt golangsdk.JSONRFC3339MilliNoZ `json:"updated_at"`
+	}
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+	*r = Volume(s.tmp)
+
+	r.CreatedAt = time.Time(s.CreatedAt)
+	r.UpdatedAt = time.Time(s.UpdatedAt)
+
+	return err
+}
+
+// VolumePage is a pagination.pager that is returned from a call to the List function.
+type VolumePage struct {
+	pagination.LinkedPageBase
+}
+
+// IsEmpty returns true if a ListResult contains no Volumes.
+func (r VolumePage) IsEmpty() (bool, error) {
+	volumes, err := ExtractVolumes(r)
+	return len(volumes) == 0, err
+}
+
+// NextPageURL uses the response's embedded link reference to navigate to the
+// next page of results.
+func (r VolumePage) NextPageURL() (string, error) {
+	var s struct {
+		Links []golangsdk.Link `json:"volumes_links"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return golangsdk.ExtractNextURL(s.Links)
+}
+
+// ExtractVolumes extracts and returns Volumes. It is used while iterating over a volumes.List call.
+func ExtractVolumes(r pagination.Page) ([]Volume, error) {
+	var s []Volume
+	err := ExtractVolumesInto(r, &s)
+	return s, err
+}
+
+type commonResult struct {
+	golangsdk.Result
+}
+
+// Extract will get the Volume object out of the commonResult object.
+func (r commonResult) Extract() (*Volume, error) {
+	var s Volume
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+func (r commonResult) ExtractInto(v interface{}) error {
+	return r.Result.ExtractIntoStructPtr(v, "volume")
+}
+
+func ExtractVolumesInto(r pagination.Page, v interface{}) error {
+	return r.(VolumePage).Result.ExtractIntoSlicePtr(v, "volumes")
+}
+
+// CreateResult contains the response body and error from a Create request.
+type CreateResult struct {
+	commonResult
+}
+
+// GetResult contains the response body and error from a Get request.
+type GetResult struct {
+	commonResult
+}
+
+// UpdateResult contains the response body and error from an Update request.
+type UpdateResult struct {
+	commonResult
+}
+
+// DeleteResult contains the response body and error from a Delete request.
+type DeleteResult struct {
+	golangsdk.ErrResult
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/blockstorage/v2/volumes/urls.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/blockstorage/v2/volumes/urls.go
@@ -1,0 +1,23 @@
+package volumes
+
+import "github.com/huaweicloud/golangsdk"
+
+func createURL(c *golangsdk.ServiceClient) string {
+	return c.ServiceURL("volumes")
+}
+
+func listURL(c *golangsdk.ServiceClient) string {
+	return c.ServiceURL("volumes", "detail")
+}
+
+func deleteURL(c *golangsdk.ServiceClient, id string) string {
+	return c.ServiceURL("volumes", id)
+}
+
+func getURL(c *golangsdk.ServiceClient, id string) string {
+	return deleteURL(c, id)
+}
+
+func updateURL(c *golangsdk.ServiceClient, id string) string {
+	return deleteURL(c, id)
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/blockstorage/v2/volumes/util.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/blockstorage/v2/volumes/util.go
@@ -1,0 +1,22 @@
+package volumes
+
+import (
+	"github.com/huaweicloud/golangsdk"
+)
+
+// WaitForStatus will continually poll the resource, checking for a particular
+// status. It will do this for the amount of seconds defined.
+func WaitForStatus(c *golangsdk.ServiceClient, id, status string, secs int) error {
+	return golangsdk.WaitFor(secs, func() (bool, error) {
+		current, err := Get(c, id).Extract()
+		if err != nil {
+			return false, err
+		}
+
+		if current.Status == status {
+			return true, nil
+		}
+
+		return false, nil
+	})
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/compute/v2/extensions/volumeattach/doc.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/compute/v2/extensions/volumeattach/doc.go
@@ -1,0 +1,30 @@
+/*
+Package volumeattach provides the ability to attach and detach volumes
+from servers.
+
+Example to Attach a Volume
+
+	serverID := "7ac8686c-de71-4acb-9600-ec18b1a1ed6d"
+	volumeID := "87463836-f0e2-4029-abf6-20c8892a3103"
+
+	createOpts := volumeattach.CreateOpts{
+		Device:   "/dev/vdc",
+		VolumeID: volumeID,
+	}
+
+	result, err := volumeattach.Create(computeClient, serverID, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Detach a Volume
+
+	serverID := "7ac8686c-de71-4acb-9600-ec18b1a1ed6d"
+	attachmentID := "ed081613-1c9b-4231-aa5e-ebfd4d87f983"
+
+	err := volumeattach.Delete(computeClient, serverID, attachmentID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+*/
+package volumeattach

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/compute/v2/extensions/volumeattach/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/compute/v2/extensions/volumeattach/requests.go
@@ -1,0 +1,60 @@
+package volumeattach
+
+import (
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/pagination"
+)
+
+// List returns a Pager that allows you to iterate over a collection of
+// VolumeAttachments.
+func List(client *golangsdk.ServiceClient, serverID string) pagination.Pager {
+	return pagination.NewPager(client, listURL(client, serverID), func(r pagination.PageResult) pagination.Page {
+		return VolumeAttachmentPage{pagination.SinglePageBase(r)}
+	})
+}
+
+// CreateOptsBuilder allows extensions to add parameters to the Create request.
+type CreateOptsBuilder interface {
+	ToVolumeAttachmentCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts specifies volume attachment creation or import parameters.
+type CreateOpts struct {
+	// Device is the device that the volume will attach to the instance as.
+	// Omit for "auto".
+	Device string `json:"device,omitempty"`
+
+	// VolumeID is the ID of the volume to attach to the instance.
+	VolumeID string `json:"volumeId" required:"true"`
+}
+
+// ToVolumeAttachmentCreateMap constructs a request body from CreateOpts.
+func (opts CreateOpts) ToVolumeAttachmentCreateMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "volumeAttachment")
+}
+
+// Create requests the creation of a new volume attachment on the server.
+func Create(client *golangsdk.ServiceClient, serverID string, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToVolumeAttachmentCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(createURL(client, serverID), b, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// Get returns public data about a previously created VolumeAttachment.
+func Get(client *golangsdk.ServiceClient, serverID, attachmentID string) (r GetResult) {
+	_, r.Err = client.Get(getURL(client, serverID, attachmentID), &r.Body, nil)
+	return
+}
+
+// Delete requests the deletion of a previous stored VolumeAttachment from
+// the server.
+func Delete(client *golangsdk.ServiceClient, serverID, attachmentID string) (r DeleteResult) {
+	_, r.Err = client.Delete(deleteURL(client, serverID, attachmentID), nil)
+	return
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/compute/v2/extensions/volumeattach/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/compute/v2/extensions/volumeattach/results.go
@@ -1,0 +1,77 @@
+package volumeattach
+
+import (
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/pagination"
+)
+
+// VolumeAttachment contains attachment information between a volume
+// and server.
+type VolumeAttachment struct {
+	// ID is a unique id of the attachment.
+	ID string `json:"id"`
+
+	// Device is what device the volume is attached as.
+	Device string `json:"device"`
+
+	// VolumeID is the ID of the attached volume.
+	VolumeID string `json:"volumeId"`
+
+	// ServerID is the ID of the instance that has the volume attached.
+	ServerID string `json:"serverId"`
+}
+
+// VolumeAttachmentPage stores a single page all of VolumeAttachment
+// results from a List call.
+type VolumeAttachmentPage struct {
+	pagination.SinglePageBase
+}
+
+// IsEmpty determines whether or not a VolumeAttachmentPage is empty.
+func (page VolumeAttachmentPage) IsEmpty() (bool, error) {
+	va, err := ExtractVolumeAttachments(page)
+	return len(va) == 0, err
+}
+
+// ExtractVolumeAttachments interprets a page of results as a slice of
+// VolumeAttachment.
+func ExtractVolumeAttachments(r pagination.Page) ([]VolumeAttachment, error) {
+	var s struct {
+		VolumeAttachments []VolumeAttachment `json:"volumeAttachments"`
+	}
+	err := (r.(VolumeAttachmentPage)).ExtractInto(&s)
+	return s.VolumeAttachments, err
+}
+
+// VolumeAttachmentResult is the result from a volume attachment operation.
+type VolumeAttachmentResult struct {
+	golangsdk.Result
+}
+
+// Extract is a method that attempts to interpret any VolumeAttachment resource
+// response as a VolumeAttachment struct.
+func (r VolumeAttachmentResult) Extract() (*VolumeAttachment, error) {
+	var s struct {
+		VolumeAttachment *VolumeAttachment `json:"volumeAttachment"`
+	}
+	err := r.ExtractInto(&s)
+	return s.VolumeAttachment, err
+}
+
+// CreateResult is the response from a Create operation. Call its Extract method
+// to interpret it as a VolumeAttachment.
+type CreateResult struct {
+	VolumeAttachmentResult
+}
+
+// GetResult is the response from a Get operation. Call its Extract method to
+// interpret it as a VolumeAttachment.
+type GetResult struct {
+	VolumeAttachmentResult
+}
+
+// DeleteResult is the response from a Delete operation. Call its ExtractErr
+// method to determine if the call succeeded or failed.
+type DeleteResult struct {
+	golangsdk.ErrResult
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/compute/v2/extensions/volumeattach/urls.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/compute/v2/extensions/volumeattach/urls.go
@@ -1,0 +1,25 @@
+package volumeattach
+
+import "github.com/huaweicloud/golangsdk"
+
+const resourcePath = "os-volume_attachments"
+
+func resourceURL(c *golangsdk.ServiceClient, serverID string) string {
+	return c.ServiceURL("servers", serverID, resourcePath)
+}
+
+func listURL(c *golangsdk.ServiceClient, serverID string) string {
+	return resourceURL(c, serverID)
+}
+
+func createURL(c *golangsdk.ServiceClient, serverID string) string {
+	return resourceURL(c, serverID)
+}
+
+func getURL(c *golangsdk.ServiceClient, serverID, aID string) string {
+	return c.ServiceURL("servers", serverID, resourcePath, aID)
+}
+
+func deleteURL(c *golangsdk.ServiceClient, serverID, aID string) string {
+	return getURL(c, serverID, aID)
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -2410,10 +2410,22 @@
 			"revisionTime": "2018-03-15T11:09:47Z"
 		},
 		{
+			"checksumSHA1": "u9yB68Ng1RAaedOTBtHe6gRZB64=",
+			"path": "github.com/huaweicloud/golangsdk/openstack/blockstorage/v2/volumes",
+			"revision": "02234c041f693ec39067f110661bb38680003a7c",
+			"revisionTime": "2018-09-28T08:16:35Z"
+		},
+		{
 			"checksumSHA1": "lpp6hBnX9xBhrnxXc0i/5fHHoWY=",
 			"path": "github.com/huaweicloud/golangsdk/openstack/cloudeyeservice/alarmrule",
 			"revision": "b30e33595f46378156035bfec5b52b350c4b2b72",
 			"revisionTime": "2018-03-15T11:09:47Z"
+		},
+		{
+			"checksumSHA1": "lFfoFNfeKUZq6XMuZEEZ490gndU=",
+			"path": "github.com/huaweicloud/golangsdk/openstack/compute/v2/extensions/volumeattach",
+			"revision": "02234c041f693ec39067f110661bb38680003a7c",
+			"revisionTime": "2018-09-28T08:16:35Z"
 		},
 		{
 			"checksumSHA1": "6cxgVwctlHbqIqO9rHVTwmDtxhk=",
@@ -2542,12 +2554,6 @@
 			"revisionTime": "2018-03-15T11:09:47Z"
 		},
 		{
-			"checksumSHA1": "+JRQECD1oxmwOI7NLLfPH3RvL7E=",
-			"path": "github.com/huaweicloud/golangsdk/openstack/sfs/v2/shares",
-			"revision": "1ef4c250ce2ea6c28095385c1800ac8a74492ca9",
-			"revisionTime": "2018-09-05T09:58:59Z"
-		},
-		{
 			"checksumSHA1": "MiR4dnIYKzUi4ry6oyYLtc6tkls=",
 			"path": "github.com/huaweicloud/golangsdk/openstack/rts/v1/softwareconfig",
 			"revision": "1ef4c250ce2ea6c28095385c1800ac8a74492ca9",
@@ -2568,6 +2574,12 @@
 		{
 			"checksumSHA1": "a9m86a8Wir9RzrMlEOd0dlXPwAs=",
 			"path": "github.com/huaweicloud/golangsdk/openstack/rts/v1/stacktemplates",
+			"revision": "1ef4c250ce2ea6c28095385c1800ac8a74492ca9",
+			"revisionTime": "2018-09-05T09:58:59Z"
+		},
+		{
+			"checksumSHA1": "+JRQECD1oxmwOI7NLLfPH3RvL7E=",
+			"path": "github.com/huaweicloud/golangsdk/openstack/sfs/v2/shares",
 			"revision": "1ef4c250ce2ea6c28095385c1800ac8a74492ca9",
 			"revisionTime": "2018-09-05T09:58:59Z"
 		},

--- a/website/docs/r/blockstorage_volume_v2.html.markdown
+++ b/website/docs/r/blockstorage_volume_v2.html.markdown
@@ -61,6 +61,8 @@ The following arguments are supported:
 * `volume_type` - (Optional) The type of volume to create.
     Changing this creates a new volume.
 
+* `cascade` - (Optional, Default:false) Specifies to delete all snapshots associated with the EVS disk.
+
 ## Attributes Reference
 
 The following attributes are exported:


### PR DESCRIPTION
This PR adds capability to delete EVS disk with cascading option so that snapshots are deleted first in order to facilitate successful volume deletion. This is useful in VBS acc tests.